### PR TITLE
Accessor for axioms/definitions

### DIFF
--- a/pytrips/ontology.py
+++ b/pytrips/ontology.py
@@ -128,8 +128,8 @@ class Trips(object):
     def get_definition(self, name):
         """Get types that contain the given name in their definitions
         """
-        name = name.split("d::")[-1].split("ont::")[-1].lower()
-        return list(set([self.__definitions[df] for df in self.__definitions.keys() if ""+name+"" in df]))
+        name = name.split("d::")[-1].split("ont::")[-1].upper() #definitions are in uppercase, names are in lower case.
+        return list(set(["ont::"+df for lst in self.__definitions.keys() for df in self.__definitions[lst] if ""+name+"" in lst]))
 
     def __getitem__(self, key):
         """if the input is "w::x" lookup x as a word

--- a/pytrips/structures/tripstype.py
+++ b/pytrips/structures/tripstype.py
@@ -1,5 +1,5 @@
 from ..helpers import get_wn_key
-
+import json
 
 class TripsType(object):
     """
@@ -13,7 +13,7 @@ class TripsType(object):
     # WARNING: arguments are currently not loaded.  There is a raw dict there
     """
 
-    def __init__(self, name, parent, children, words, wordnet, arguments, ont):
+    def __init__(self, name, parent, children, words, wordnet, arguments, definitions, ont):
         self.__name = name.lower()
         if parent:
             self.__parent = parent.lower()
@@ -24,6 +24,7 @@ class TripsType(object):
         self.__words = [w.lower() for w in words]
         self.__wordnet = [w.lower() for w in wordnet]
         self.__wordnet_keys = [get_wn_key(s) for s in self.__wordnet if get_wn_key(s)]
+        self.__definitions = json.loads(json.dumps(definitions))
         self.__ont = ont
         # TODO: set numerical id
 
@@ -48,6 +49,10 @@ class TripsType(object):
     @property
     def arguments(self):
         return self.__arguments[:]
+
+    @property
+    def definitions(self):
+        return self.__definitions[:]
 
     @property
     def words(self):


### PR DESCRIPTION
Two functions added:
1. Look up definitions of an ont type; e.g. `ont['asleep-val'].definitions`
2. find ont types whose definitions have the given ont type; e.g. `ont['d::move']`

* Returned definitions are lists of strings in uppercase, just as in the ontology.json file. For example, `ont['asleep-val].definitions` returns ['NOT', ['AWAKE-VAL', 'FIGURE', '?NEUTRAL']]